### PR TITLE
Remove dependency on nvr, now that nvim has --remote support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ with registers `+` and `*`.
 
 Synchronization of the alphabetic registers is supported with these editors:
 
-- Neovim (requires `nvr`)
+- Neovim (>=0.9)
 - Vim (requires +clientserver support)
 
 Example:

--- a/functions/→evil-registers::setup-editor
+++ b/functions/→evil-registers::setup-editor
@@ -23,15 +23,19 @@ for context (${(M)all_styles:#:zle:evil-registers:*}){
 		nvim)
 			→evil-registers::nvim-yank(){
 				local MATCH MBEGIN MEND
-				timeout -k 15 10 nvr -s --nostart --remote-expr \
+				local server=({$XDG_RUNTIME_DIR,/tmp}/nvim*(N=Y1))
+				(($#server)) &&
+					timeout -k 15 10 nvim --server $server[1] --remote-expr \
 					"setreg('$1', \"${2//(#m)[\\\"]/\\$MATCH}\")" >/dev/null
 			}
 			→evil-registers::nvim-put(){
-				if [[ $1 = [%#] ]]; then
-					nvr -s --nostart --remote-expr "expand('$1:p')"
-				else
-					nvr -s --nostart --remote-expr "getreg('$_evil_register')"
-				fi
+				local server=({$XDG_RUNTIME_DIR,/tmp}/nvim*(N=Y1))
+				(($#server)) &&
+					if [[ $1 = [%#] ]]; then
+						nvim --remote-expr "expand('$1:p')"
+					else
+						nvim --remote-expr "getreg('$_evil_register')"
+					fi
 			}
 		;;
 		vim)

--- a/functions/→evil-registers::setup-editor
+++ b/functions/→evil-registers::setup-editor
@@ -21,20 +21,22 @@ for context (${(M)all_styles:#:zle:evil-registers:*}){
 	# check if the functions are already defined
 	(($+functions[→evil-registers::${editor}-yank])) || case $editor in
 		nvim)
+      # After neovim/neovim#22970 is fixed, we can remove 2>&1 and properly 
+      # put errors on zle -M.
 			→evil-registers::nvim-yank(){
 				local MATCH MBEGIN MEND
 				local server=({$XDG_RUNTIME_DIR,/tmp}/nvim*(N=Y1))
 				(($#server)) &&
 					timeout -k 15 10 nvim --headless --server $server[1] --remote-expr \
-					"setreg('$1', \"${2//(#m)[\\\"]/\\$MATCH}\")" >/dev/null
+					"setreg('$1', \"${2//(#m)[\\\"]/\\$MATCH}\")" >/dev/null 2>&1
 			}
 			→evil-registers::nvim-put(){
 				local server=({$XDG_RUNTIME_DIR,/tmp}/nvim*(N=Y1))
 				(($#server)) &&
 					if [[ $1 = [%#] ]]; then
-						nvim --headless --server $server[1] --remote-expr "expand('$1:p')"
+						nvim --headless --server $server[1] --remote-expr "expand('$1:p')" 2>&1
 					else
-						nvim --headless --server $server[1] --remote-expr "getreg('$_evil_register')"
+						nvim --headless --server $server[1] --remote-expr "getreg('$_evil_register')" 2>&1
 					fi
 			}
 		;;

--- a/functions/→evil-registers::setup-editor
+++ b/functions/→evil-registers::setup-editor
@@ -25,16 +25,16 @@ for context (${(M)all_styles:#:zle:evil-registers:*}){
 				local MATCH MBEGIN MEND
 				local server=({$XDG_RUNTIME_DIR,/tmp}/nvim*(N=Y1))
 				(($#server)) &&
-					timeout -k 15 10 nvim --server $server[1] --remote-expr \
+					timeout -k 15 10 nvim --headless --server $server[1] --remote-expr \
 					"setreg('$1', \"${2//(#m)[\\\"]/\\$MATCH}\")" >/dev/null
 			}
 			→evil-registers::nvim-put(){
 				local server=({$XDG_RUNTIME_DIR,/tmp}/nvim*(N=Y1))
 				(($#server)) &&
 					if [[ $1 = [%#] ]]; then
-						nvim --remote-expr "expand('$1:p')"
+						nvim --headless --server $server[1] --remote-expr "expand('$1:p')"
 					else
-						nvim --remote-expr "getreg('$_evil_register')"
+						nvim --headless --server $server[1] --remote-expr "getreg('$_evil_register')"
 					fi
 			}
 		;;


### PR DESCRIPTION
Blocked by neovim/neovim#22970.